### PR TITLE
show Notification List with correct red-dot logic

### DIFF
--- a/CathayInterviewApp.xcodeproj/project.pbxproj
+++ b/CathayInterviewApp.xcodeproj/project.pbxproj
@@ -20,6 +20,10 @@
 		1CB698BF2D0026B7009332BF /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698BE2D0026B7009332BF /* MainViewModel.swift */; };
 		1CB698C82D002CB4009332BF /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698C72D002CB4009332BF /* MainViewController.swift */; };
 		1CB698CB2D004283009332BF /* ExtensionUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698CA2D004283009332BF /* ExtensionUIColor.swift */; };
+		1CB698CD2D004FAA009332BF /* NotificationListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698CC2D004FAA009332BF /* NotificationListViewController.swift */; };
+		1CB698CF2D0050E9009332BF /* NotificationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698CE2D0050E9009332BF /* NotificationCell.swift */; };
+		1CB698D12D005105009332BF /* NotificationListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698D02D005105009332BF /* NotificationListViewModel.swift */; };
+		1CB698D42D008D16009332BF /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698D32D008D16009332BF /* NotificationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +42,10 @@
 		1CB698BE2D0026B7009332BF /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		1CB698C72D002CB4009332BF /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		1CB698CA2D004283009332BF /* ExtensionUIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionUIColor.swift; sourceTree = "<group>"; };
+		1CB698CC2D004FAA009332BF /* NotificationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationListViewController.swift; sourceTree = "<group>"; };
+		1CB698CE2D0050E9009332BF /* NotificationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCell.swift; sourceTree = "<group>"; };
+		1CB698D02D005105009332BF /* NotificationListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationListViewModel.swift; sourceTree = "<group>"; };
+		1CB698D32D008D16009332BF /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +81,7 @@
 				1CB6989B2CFFF235009332BF /* AppDelegate.swift */,
 				1CB6989D2CFFF235009332BF /* SceneDelegate.swift */,
 				1CB6989F2CFFF235009332BF /* ViewController.swift */,
+				1CB698D22D008D07009332BF /* Manager */,
 				1CB698C22D00279A009332BF /* Model */,
 				1CB698C52D0027F0009332BF /* Service */,
 				1CB698C42D0027C8009332BF /* View */,
@@ -98,6 +107,7 @@
 			isa = PBXGroup;
 			children = (
 				1CB698BE2D0026B7009332BF /* MainViewModel.swift */,
+				1CB698D02D005105009332BF /* NotificationListViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -106,6 +116,8 @@
 			isa = PBXGroup;
 			children = (
 				1CB698C72D002CB4009332BF /* MainViewController.swift */,
+				1CB698CC2D004FAA009332BF /* NotificationListViewController.swift */,
+				1CB698CE2D0050E9009332BF /* NotificationCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -134,6 +146,14 @@
 				1CB698CA2D004283009332BF /* ExtensionUIColor.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		1CB698D22D008D07009332BF /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				1CB698D32D008D16009332BF /* NotificationManager.swift */,
+			);
+			path = Manager;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -207,14 +227,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1CB698CD2D004FAA009332BF /* NotificationListViewController.swift in Sources */,
 				1CB698A02CFFF235009332BF /* ViewController.swift in Sources */,
 				1CB698BD2D002679009332BF /* APIService.swift in Sources */,
 				1CB698B92D0025F3009332BF /* Notification.swift in Sources */,
+				1CB698D42D008D16009332BF /* NotificationManager.swift in Sources */,
+				1CB698CF2D0050E9009332BF /* NotificationCell.swift in Sources */,
 				1CB698CB2D004283009332BF /* ExtensionUIColor.swift in Sources */,
 				1CB6989C2CFFF235009332BF /* AppDelegate.swift in Sources */,
 				1CB6989E2CFFF235009332BF /* SceneDelegate.swift in Sources */,
 				1CB698A62CFFF235009332BF /* CathayInterviewApp.xcdatamodeld in Sources */,
 				1CB698C82D002CB4009332BF /* MainViewController.swift in Sources */,
+				1CB698D12D005105009332BF /* NotificationListViewModel.swift in Sources */,
 				1CB698BB2D002664009332BF /* Account.swift in Sources */,
 				1CB698BF2D0026B7009332BF /* MainViewModel.swift in Sources */,
 			);

--- a/CathayInterviewApp.xcodeproj/project.pbxproj
+++ b/CathayInterviewApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		1CB698BB2D002664009332BF /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698BA2D002664009332BF /* Account.swift */; };
 		1CB698BD2D002679009332BF /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698BC2D002679009332BF /* APIService.swift */; };
 		1CB698BF2D0026B7009332BF /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698BE2D0026B7009332BF /* MainViewModel.swift */; };
+		1CB698C82D002CB4009332BF /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698C72D002CB4009332BF /* MainViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		1CB698BA2D002664009332BF /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		1CB698BC2D002679009332BF /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		1CB698BE2D0026B7009332BF /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
+		1CB698C72D002CB4009332BF /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +102,7 @@
 		1CB698C42D0027C8009332BF /* View */ = {
 			isa = PBXGroup;
 			children = (
+				1CB698C72D002CB4009332BF /* MainViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -199,6 +202,7 @@
 				1CB6989C2CFFF235009332BF /* AppDelegate.swift in Sources */,
 				1CB6989E2CFFF235009332BF /* SceneDelegate.swift in Sources */,
 				1CB698A62CFFF235009332BF /* CathayInterviewApp.xcdatamodeld in Sources */,
+				1CB698C82D002CB4009332BF /* MainViewController.swift in Sources */,
 				1CB698BB2D002664009332BF /* Account.swift in Sources */,
 				1CB698BF2D0026B7009332BF /* MainViewModel.swift in Sources */,
 			);

--- a/CathayInterviewApp.xcodeproj/project.pbxproj
+++ b/CathayInterviewApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		1CB698BD2D002679009332BF /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698BC2D002679009332BF /* APIService.swift */; };
 		1CB698BF2D0026B7009332BF /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698BE2D0026B7009332BF /* MainViewModel.swift */; };
 		1CB698C82D002CB4009332BF /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698C72D002CB4009332BF /* MainViewController.swift */; };
+		1CB698CB2D004283009332BF /* ExtensionUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB698CA2D004283009332BF /* ExtensionUIColor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		1CB698BC2D002679009332BF /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		1CB698BE2D0026B7009332BF /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		1CB698C72D002CB4009332BF /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		1CB698CA2D004283009332BF /* ExtensionUIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionUIColor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +78,7 @@
 				1CB698C42D0027C8009332BF /* View */,
 				1CB698C32D0027B1009332BF /* ViewModel */,
 				1CB698C62D002814009332BF /* Resources */,
+				1CB698C92D00422A009332BF /* Extensions */,
 				1CB698AC2CFFF235009332BF /* Info.plist */,
 				1CB698A42CFFF235009332BF /* CathayInterviewApp.xcdatamodeld */,
 			);
@@ -123,6 +126,14 @@
 				1CB698A92CFFF235009332BF /* LaunchScreen.storyboard */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		1CB698C92D00422A009332BF /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				1CB698CA2D004283009332BF /* ExtensionUIColor.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -199,6 +210,7 @@
 				1CB698A02CFFF235009332BF /* ViewController.swift in Sources */,
 				1CB698BD2D002679009332BF /* APIService.swift in Sources */,
 				1CB698B92D0025F3009332BF /* Notification.swift in Sources */,
+				1CB698CB2D004283009332BF /* ExtensionUIColor.swift in Sources */,
 				1CB6989C2CFFF235009332BF /* AppDelegate.swift in Sources */,
 				1CB6989E2CFFF235009332BF /* SceneDelegate.swift in Sources */,
 				1CB698A62CFFF235009332BF /* CathayInterviewApp.xcdatamodeld in Sources */,

--- a/CathayInterviewApp/Extensions/ExtensionUIColor.swift
+++ b/CathayInterviewApp/Extensions/ExtensionUIColor.swift
@@ -1,0 +1,8 @@
+//
+//  ExtensionUIColor.swift
+//  CathayInterviewApp
+//
+//  Created by Vickyhereiam on 2024/12/4.
+//
+
+import Foundation

--- a/CathayInterviewApp/Extensions/ExtensionUIColor.swift
+++ b/CathayInterviewApp/Extensions/ExtensionUIColor.swift
@@ -5,4 +5,20 @@
 //  Created by Vickyhereiam on 2024/12/4.
 //
 
-import Foundation
+import UIKit
+
+extension UIColor {
+    static func fromHex(_ hex: String, alpha: CGFloat = 1.0) -> UIColor {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+        
+        var rgb: UInt64 = 0
+        Scanner(string: hexSanitized).scanHexInt64(&rgb)
+        
+        let red = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
+        let green = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
+        let blue = CGFloat(rgb & 0x0000FF) / 255.0
+        
+        return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/CathayInterviewApp/Manager/NotificationManager.swift
+++ b/CathayInterviewApp/Manager/NotificationManager.swift
@@ -1,0 +1,81 @@
+//
+//  NotificationManager.swift
+//  CathayInterviewApp
+//
+//  Created by Vickyhereiam on 2024/12/4.
+//
+import Foundation
+
+class NotificationManager {
+    static let shared = NotificationManager()
+    
+    private init() {
+        readNotificationIDs = Set(UserDefaults.standard.array(forKey: "ReadNotificationIDs") as? [String] ?? [])
+    }
+    
+    private var notifications: [Notification] = [] {
+        didSet {
+            notifyObservers()
+        }
+    }
+    
+    private var readNotificationIDs: Set<String> = []
+    
+    private var observers: [() -> Void] = []
+    
+    func addObserver(_ observer: @escaping () -> Void) {
+        observers.append(observer)
+    }
+    
+    private func notifyObservers() {
+        for observer in observers {
+            observer()
+        }
+    }
+    
+    func fetchNotifications(completion: @escaping ([Notification]) -> Void) {
+        APIService.shared.fetchNotifications { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let fetchedNotifications):
+               
+                self.notifications = fetchedNotifications.map { notification in
+                    var updatedNotification = notification
+                    if self.readNotificationIDs.contains(notification.id) {
+                        updatedNotification.status = true
+                    }
+                    return updatedNotification
+                }
+                completion(self.notifications)
+            case .failure(let error):
+                print("Error fetching notifications: \(error)")
+                completion([])
+            }
+        }
+    }
+    
+    func getNotifications() -> [Notification] {
+        return notifications
+    }
+    
+    func markAsRead(notification: Notification) {
+        if let index = notifications.firstIndex(where: { $0.id == notification.id }) {
+            
+            notifications[index].status = true
+            
+            readNotificationIDs.insert(notification.id)
+            
+            UserDefaults.standard.set(Array(readNotificationIDs), forKey: "ReadNotificationIDs")
+            
+            notifyObservers()
+            
+            print("Marked notification \(notifications[index].id) as read")
+        } else {
+            print("Notification with id \(notification.id) not found.")
+        }
+    }
+    
+    func hasUnreadNotifications() -> Bool {
+        return notifications.contains { !$0.status }
+    }
+}

--- a/CathayInterviewApp/Model/Notification.swift
+++ b/CathayInterviewApp/Model/Notification.swift
@@ -17,11 +17,54 @@ struct NotificationResult: Decodable {
     let messages: [Notification]
 }
 
-struct Notification: Decodable {
-    let status: Bool
-    let updateDateTime: String
+struct Notification: Equatable, Decodable, Identifiable {
+    let id: String
     let title: String
     let message: String
+    var status: Bool
+    let updateDateTime: String
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case message
+        case status
+        case updateDateTime
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.message = try container.decode(String.self, forKey: .message)
+        self.status = try container.decode(Bool.self, forKey: .status)
+        let rawDateTime = try container.decode(String.self, forKey: .updateDateTime)
+        self.updateDateTime = Notification.standardizeDateTime(rawDateTime)
+        self.id = Notification.generateID(title: self.title, message: self.message, updateDateTime: self.updateDateTime)
+    }
+
+    // use title、message and updateDateTime to create an hash value into id
+    static func generateID(title: String, message: String, updateDateTime: String) -> String {
+        let combinedString = title + message + updateDateTime
+        return String(combinedString.hashValue)
+    }
+
+    static func standardizeDateTime(_ rawDateTime: String) -> String {
+        let dateFormats = ["yyyy/MM/dd HH:mm:ss", "HH:mm:ss yyyy/MM/dd", "yyyy/MM/dd HH:mm", "HH:mm yyyy/MM/dd"]
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        for format in dateFormats {
+            formatter.dateFormat = format
+            if let date = formatter.date(from: rawDateTime) {
+                formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+                return formatter.string(from: date)
+            }
+        }
+        return rawDateTime
+    }
 }
+
+
+
+
+
 
 

--- a/CathayInterviewApp/Model/Notification.swift
+++ b/CathayInterviewApp/Model/Notification.swift
@@ -7,10 +7,21 @@
 
 import Foundation
 
-struct Notification: Decodable {
-    let id: Int
-    let title: String
-    let body: String
-    let date: String
+struct NotificationResponse: Decodable {
+    let msgCode: String
+    let msgContent: String
+    let result: NotificationResult
 }
+
+struct NotificationResult: Decodable {
+    let messages: [Notification]
+}
+
+struct Notification: Decodable {
+    let status: Bool
+    let updateDateTime: String
+    let title: String
+    let message: String
+}
+
 

--- a/CathayInterviewApp/SceneDelegate.swift
+++ b/CathayInterviewApp/SceneDelegate.swift
@@ -19,7 +19,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = MainViewController()
+        let mainVC = MainViewController()
+        let navController = UINavigationController(rootViewController: mainVC)
+        window.rootViewController = navController
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/CathayInterviewApp/SceneDelegate.swift
+++ b/CathayInterviewApp/SceneDelegate.swift
@@ -8,48 +8,53 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
-
+    
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = MainViewController()
+        self.window = window
+        window.makeKeyAndVisible()
     }
-
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
-
+    
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
-
+    
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
-
+    
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
-
+        
         // Save changes in the application's managed object context when the application transitions to the background.
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
-
-
+    
+    
 }
 

--- a/CathayInterviewApp/Service/APIService.swift
+++ b/CathayInterviewApp/Service/APIService.swift
@@ -29,9 +29,10 @@ class APIService {
             }
 
             do {
-                let notifications = try JSONDecoder().decode([Notification].self, from: data)
-                completion(.success(notifications))
+                let response = try JSONDecoder().decode(NotificationResponse.self, from: data)
+                completion(.success(response.result.messages))
             } catch {
+                print("Decoding Error: \(error)")
                 completion(.failure(error))
             }
         }.resume()

--- a/CathayInterviewApp/Service/APIService.swift
+++ b/CathayInterviewApp/Service/APIService.swift
@@ -9,33 +9,33 @@ import Foundation
 
 class APIService {
     static let shared = APIService()
-
+    
     func fetchNotifications(completion: @escaping (Result<[Notification], Error>) -> Void) {
         let urlString = "https://willywu0201.github.io/data/notificationList.json"
         guard let url = URL(string: urlString) else {
-            completion(.failure(NSError(domain: "Invalid URL", code: -1, userInfo: nil)))
+            completion(.failure(NSError(domain: "InvalidURL", code: -1, userInfo: nil)))
             return
         }
-
+        
         URLSession.shared.dataTask(with: url) { data, response, error in
             if let error = error {
                 completion(.failure(error))
                 return
             }
-
             guard let data = data else {
-                completion(.failure(NSError(domain: "No Data", code: -1, userInfo: nil)))
+                completion(.failure(NSError(domain: "NoData", code: -1, userInfo: nil)))
                 return
             }
-
+            
             do {
-                let response = try JSONDecoder().decode(NotificationResponse.self, from: data)
-                completion(.success(response.result.messages))
+                let decoder = JSONDecoder()
+                let notificationResponse = try decoder.decode(NotificationResponse.self, from: data)
+                let notifications = notificationResponse.result.messages
+                completion(.success(notifications))
             } catch {
-                print("Decoding Error: \(error)")
+                print("Decoding error: \(error)")
                 completion(.failure(error))
             }
         }.resume()
     }
 }
-

--- a/CathayInterviewApp/View/MainViewController.swift
+++ b/CathayInterviewApp/View/MainViewController.swift
@@ -1,0 +1,59 @@
+//
+//  MainViewController.swift
+//  CathayInterviewApp
+//
+//  Created by Vickyhereiam on 2024/12/4.
+//
+
+import UIKit
+
+class MainViewController: UIViewController {
+    
+    private let viewModel = MainViewModel()
+    private let notificationButton = UIButton(type: .system)
+    private let redDotLabel = UILabel()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        setupUI()
+        setupBindings()
+        viewModel.fetchNotifications()
+    }
+    
+    private func setupUI() {
+        // 通知按鈕
+        notificationButton.setImage(UIImage(systemName: "bell"), for: .normal)
+        notificationButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(notificationButton)
+        
+        // 紅點
+        redDotLabel.backgroundColor = .red
+        redDotLabel.layer.cornerRadius = 5
+        redDotLabel.clipsToBounds = true
+        redDotLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(redDotLabel)
+        
+        // 設置約束
+        NSLayoutConstraint.activate([
+            notificationButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            notificationButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            notificationButton.widthAnchor.constraint(equalToConstant: 30),
+            notificationButton.heightAnchor.constraint(equalToConstant: 30),
+            
+            redDotLabel.widthAnchor.constraint(equalToConstant: 10),
+            redDotLabel.heightAnchor.constraint(equalToConstant: 10),
+            redDotLabel.centerXAnchor.constraint(equalTo: notificationButton.trailingAnchor),
+            redDotLabel.centerYAnchor.constraint(equalTo: notificationButton.topAnchor)
+        ])
+    }
+    
+    private func setupBindings() {
+        viewModel.updateUI = { [weak self] in
+            DispatchQueue.main.async {
+                self?.redDotLabel.isHidden = !self!.viewModel.hasNotifications
+            }
+        }
+    }
+}
+

--- a/CathayInterviewApp/View/MainViewController.swift
+++ b/CathayInterviewApp/View/MainViewController.swift
@@ -13,39 +13,47 @@ class MainViewController: UIViewController {
     private let notificationButton = UIButton(type: .system)
     private let redDotLabel = UILabel()
     
+    struct RedDotPosition {
+        static let offsetX: CGFloat = -5
+        static let offsetY: CGFloat = 5
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
         setupUI()
         setupBindings()
         viewModel.fetchNotifications()
     }
     
     private func setupUI() {
-        // 通知按鈕
+        view.backgroundColor = .white
+      
         notificationButton.setImage(UIImage(systemName: "bell"), for: .normal)
+        notificationButton.tintColor = .black
         notificationButton.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(notificationButton)
         
-        // 紅點
-        redDotLabel.backgroundColor = .red
+        redDotLabel.backgroundColor = UIColor.fromHex("#FF5733")
         redDotLabel.layer.cornerRadius = 5
+        redDotLabel.layer.borderWidth = 1.5
+        redDotLabel.layer.borderColor = UIColor.white.cgColor
         redDotLabel.clipsToBounds = true
         redDotLabel.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(redDotLabel)
-        
-        // 設置約束
+      
         NSLayoutConstraint.activate([
             notificationButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
             notificationButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             notificationButton.widthAnchor.constraint(equalToConstant: 30),
             notificationButton.heightAnchor.constraint(equalToConstant: 30),
-            
+
             redDotLabel.widthAnchor.constraint(equalToConstant: 10),
             redDotLabel.heightAnchor.constraint(equalToConstant: 10),
-            redDotLabel.centerXAnchor.constraint(equalTo: notificationButton.trailingAnchor),
-            redDotLabel.centerYAnchor.constraint(equalTo: notificationButton.topAnchor)
+
+            redDotLabel.topAnchor.constraint(equalTo: notificationButton.topAnchor, constant: RedDotPosition.offsetY),
+            redDotLabel.trailingAnchor.constraint(equalTo: notificationButton.trailingAnchor, constant: RedDotPosition.offsetX)
         ])
+
     }
     
     private func setupBindings() {

--- a/CathayInterviewApp/View/MainViewController.swift
+++ b/CathayInterviewApp/View/MainViewController.swift
@@ -10,12 +10,11 @@ import UIKit
 class MainViewController: UIViewController {
     
     private let viewModel = MainViewModel()
-    private let notificationButton = UIButton(type: .system)
     private let redDotLabel = UILabel()
     
     struct RedDotPosition {
-        static let offsetX: CGFloat = -5
-        static let offsetY: CGFloat = 5
+        static let offsetX: CGFloat = -3
+        static let offsetY: CGFloat = 3
     }
 
     override func viewDidLoad() {
@@ -24,14 +23,22 @@ class MainViewController: UIViewController {
         setupBindings()
         viewModel.fetchNotifications()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.fetchNotifications()
+    }
     
     private func setupUI() {
-        view.backgroundColor = .white
-      
+        view.backgroundColor = UIColor.fromHex("#F5F5F5")
+        
+        let notificationButton = UIButton(type: .system)
         notificationButton.setImage(UIImage(systemName: "bell"), for: .normal)
         notificationButton.tintColor = .black
-        notificationButton.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(notificationButton)
+        notificationButton.addTarget(self, action: #selector(notificationButtonTapped), for: .touchUpInside)
+        
+        let barButtonItem = UIBarButtonItem(customView: notificationButton)
+        self.navigationItem.rightBarButtonItem = barButtonItem
         
         redDotLabel.backgroundColor = UIColor.fromHex("#FF5733")
         redDotLabel.layer.cornerRadius = 5
@@ -39,29 +46,28 @@ class MainViewController: UIViewController {
         redDotLabel.layer.borderColor = UIColor.white.cgColor
         redDotLabel.clipsToBounds = true
         redDotLabel.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(redDotLabel)
-      
+        notificationButton.addSubview(redDotLabel)
+        
         NSLayoutConstraint.activate([
-            notificationButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
-            notificationButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            notificationButton.widthAnchor.constraint(equalToConstant: 30),
-            notificationButton.heightAnchor.constraint(equalToConstant: 30),
-
             redDotLabel.widthAnchor.constraint(equalToConstant: 10),
             redDotLabel.heightAnchor.constraint(equalToConstant: 10),
-
             redDotLabel.topAnchor.constraint(equalTo: notificationButton.topAnchor, constant: RedDotPosition.offsetY),
             redDotLabel.trailingAnchor.constraint(equalTo: notificationButton.trailingAnchor, constant: RedDotPosition.offsetX)
         ])
-
+    }
+    
+    @objc private func notificationButtonTapped() {
+        let notificationListVC = NotificationListViewController()
+        navigationController?.pushViewController(notificationListVC, animated: true)
     }
     
     private func setupBindings() {
         viewModel.updateUI = { [weak self] in
             DispatchQueue.main.async {
-                self?.redDotLabel.isHidden = !self!.viewModel.hasNotifications
+                let hasNotifications = self?.viewModel.hasNotifications ?? false
+                self?.redDotLabel.isHidden = !hasNotifications
+                print("MainViewController updated redDotLabel: hasNotifications = \(hasNotifications)")
             }
         }
     }
 }
-

--- a/CathayInterviewApp/View/NotificationCell.swift
+++ b/CathayInterviewApp/View/NotificationCell.swift
@@ -1,0 +1,70 @@
+//
+//  NotificationCell.swift
+//  CathayInterviewApp
+//
+//  Created by Vickyhereiam on 2024/12/4.
+//
+
+import UIKit
+
+class NotificationCell: UITableViewCell {
+    static let identifier = "NotificationCell"
+    
+    private let titleLabel = UILabel()
+    private let messageLabel = UILabel()
+    private let redDotView = UIView()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI() {
+        contentView.backgroundColor = UIColor.fromHex("#F5F5F5")
+        titleLabel.font = .boldSystemFont(ofSize: 16)
+       
+        messageLabel.font = .systemFont(ofSize: 14)
+        messageLabel.textColor = .darkGray
+        messageLabel.numberOfLines = 2
+      
+        redDotView.backgroundColor = UIColor.fromHex("#FF5733")
+        redDotView.layer.cornerRadius = 5
+        redDotView.clipsToBounds = true
+        redDotView.translatesAutoresizingMaskIntoConstraints = false
+        redDotView.isHidden = true
+        
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, messageLabel])
+        stackView.axis = .vertical
+        stackView.spacing = 5
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        contentView.addSubview(stackView)
+        contentView.addSubview(redDotView)
+        
+       
+        NSLayoutConstraint.activate([
+           
+            redDotView.widthAnchor.constraint(equalToConstant: 10),
+            redDotView.heightAnchor.constraint(equalToConstant: 10),
+            redDotView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+            redDotView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 15),
+            
+            
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
+            stackView.leadingAnchor.constraint(equalTo: redDotView.trailingAnchor, constant: 8),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -15)
+        ])
+    }
+    
+    func configure(with notification: Notification) {
+        
+        titleLabel.text = notification.title
+        messageLabel.text = notification.message
+        redDotView.isHidden = notification.status
+    }
+}

--- a/CathayInterviewApp/View/NotificationListViewController.swift
+++ b/CathayInterviewApp/View/NotificationListViewController.swift
@@ -1,0 +1,89 @@
+//
+//  NotificationListViewController.swift
+//  CathayInterviewApp
+//
+//  Created by Vickyhereiam on 2024/12/4.
+//
+
+import UIKit
+
+class NotificationListViewController: UIViewController {
+    
+    private let viewModel = NotificationListViewModel()
+    
+    private let tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.register(NotificationCell.self, forCellReuseIdentifier: NotificationCell.identifier)
+        return tableView
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupBindings()
+        viewModel.fetchNotifications()
+        let backButton = UIBarButtonItem(image: UIImage(systemName: "arrow.backward"),
+                                         style: .plain,
+                                         target: self,
+                                         action: #selector(backButtonTapped))
+        backButton.tintColor = .black
+        navigationItem.leftBarButtonItem = backButton
+    }
+    
+    @objc private func backButtonTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    private func setupUI() {
+        view.backgroundColor = UIColor.fromHex("#F5F5F5")
+        title = "Notifications"
+        
+        tableView.backgroundColor = UIColor.fromHex("#F5F5F5")
+        tableView.separatorStyle = .none
+        
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+    
+    private func setupBindings() {
+        viewModel.updateUI = { [weak self] in
+            DispatchQueue.main.async {
+                self?.tableView.reloadData()
+                print("NotificationListViewController reloaded tableView")
+            }
+        }
+    }
+}
+
+extension NotificationListViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        print("Number of rows: \(viewModel.notificationCount)") // 打印行數，檢查是否為 0
+        return viewModel.notificationCount
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: NotificationCell.identifier, for: indexPath) as? NotificationCell else {
+            return UITableViewCell()
+        }
+        let notification = viewModel.notification(at: indexPath.row)
+        print("Notification: \(notification)")
+        cell.configure(with: notification)
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        viewModel.markAsRead(at: indexPath.row)
+        tableView.deselectRow(at: indexPath, animated: true)
+        print("Did select notification at index \(indexPath.row)")
+    }
+}

--- a/CathayInterviewApp/ViewModel/MainViewModel.swift
+++ b/CathayInterviewApp/ViewModel/MainViewModel.swift
@@ -8,32 +8,23 @@
 import Foundation
 
 class MainViewModel {
-    private var notifications: [Notification] = [] {
-        didSet {
-            self.updateUI?()
+    var updateUI: (() -> Void)?
+    
+    init() {
+        NotificationManager.shared.addObserver { [weak self] in
+            self?.updateUI?()
+            print("MainViewModel notified to update UI")
         }
     }
-
-    var updateUI: (() -> Void)?
-
-    var notificationCount: Int {
-        notifications.count
-    }
-
+    
     var hasNotifications: Bool {
-        !notifications.isEmpty
+        return NotificationManager.shared.hasUnreadNotifications()
     }
-
+    
     func fetchNotifications() {
-        APIService.shared.fetchNotifications { [weak self] result in
-            switch result {
-            case .success(let notifications):
-                print("Fetched Notifications: \(notifications)")
-                self?.notifications = notifications
-            case .failure(let error):
-                print("Error fetching notifications: \(error)")
-                self?.notifications = []
-            }
+        NotificationManager.shared.fetchNotifications { [weak self] _ in
+            self?.updateUI?()
+            print("MainViewModel fetched notifications")
         }
     }
 }

--- a/CathayInterviewApp/ViewModel/MainViewModel.swift
+++ b/CathayInterviewApp/ViewModel/MainViewModel.swift
@@ -28,6 +28,7 @@ class MainViewModel {
         APIService.shared.fetchNotifications { [weak self] result in
             switch result {
             case .success(let notifications):
+                print("Fetched Notifications: \(notifications)")
                 self?.notifications = notifications
             case .failure(let error):
                 print("Error fetching notifications: \(error)")

--- a/CathayInterviewApp/ViewModel/NotificationListViewModel.swift
+++ b/CathayInterviewApp/ViewModel/NotificationListViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  NotificationListViewModel.swift
+//  CathayInterviewApp
+//
+//  Created by Vickyhereiam on 2024/12/4.
+//
+
+import Foundation
+
+class NotificationListViewModel {
+    private var notifications: [Notification] = []
+    
+    var updateUI: (() -> Void)?
+    
+    init() {
+        NotificationManager.shared.addObserver { [weak self] in
+            self?.notifications = NotificationManager.shared.getNotifications()
+            self?.updateUI?()
+            print("NotificationListViewModel notified to update UI")
+        }
+    }
+    
+    var notificationCount: Int {
+        return notifications.count
+    }
+    
+    func notification(at index: Int) -> Notification {
+        return notifications[index]
+    }
+    
+    func fetchNotifications() {
+        NotificationManager.shared.fetchNotifications { [weak self] notifications in
+            self?.notifications = notifications
+            self?.updateUI?()
+            print("NotificationListViewModel fetched notifications")
+        }
+    }
+    
+    func markAsRead(at index: Int) {
+        let notification = notifications[index]
+        NotificationManager.shared.markAsRead(notification: notification)
+        print("NotificationListViewModel marked notification at index \(index) as read")
+    }
+    
+    func areAllNotificationsRead() -> Bool {
+        return !notifications.contains(where: { !$0.status })
+    }
+}


### PR DESCRIPTION
feature: show Notification List with correct red-dot logic

- Addressed the issue where duplicate notifications shared the same ID. 
- Combined title, message, and updateDateTime fields to generate unique IDs. 
- Use Userdefault to store red-dot logic to correctly reflect the read/unread status.
- Solve duplicate notifications causing incorrect read status  